### PR TITLE
Rename method `compare` -> `haplotype_arf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Final release to go with publication of Fritze et al.
 
 **Breaking change:** renamed `compare` to `haplotype_arf`, because there are other comparison
 methods that we might implement here, and each would return a different object.
+For now, `compare` does the same thing but raises a DeprecationWarning.
 
 ## [0.1] - 2024-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2] - 2025-09-09
+
+Final release to go with publication of Fritze et al.
+
+**Breaking change:** renamed `compare` to `haplotype_arf`, because there are other comparison
+methods that we might implement here, and each would return a different object.
+
 ## [0.1] - 2024-12-14
 
 Initial release of functionality, providing tools to "match" nodes between tree sequences

--- a/CITATION.md
+++ b/CITATION.md
@@ -3,10 +3,10 @@
 # Citing tscompare
 
 If you use `tscompare` in your work, please cite the
-[2024 bioRxiv paper](<https://www.biorxiv.org/content/10.1101/2024.11.30.626138>):
+[2025 bioRxiv paper](<https://www.biorxiv.org/content/10.1101/2024.11.30.626138v4>):
 
->  Halley Fritze, Nathaniel Pope, Jerome Kelleher, and Peter Ralph (2024),
+>  Halley Fritze, Nathaniel Pope, Jerome Kelleher, and Peter Ralph (2025),
 > *A forest is more than its trees: haplotypes and ARGs*,
-> bioRxiv 2024.11.30.626138. https://www.biorxiv.org/content/10.1101/2024.11.30.626138
+> bioRxiv 2024.11.30.626138v4. https://www.biorxiv.org/content/10.1101/2024.11.30.626138v4
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # tscompare
-Utilities for comparing tree sequences
 
-**Under construction, 1 December 2024:** this code will be available very soon.
+Utilities for comparing ARGs in tree sequence format;
+at present this only contains tools described in;
+[Fritze et al, "A forest is more than its trees: haplotypes and ancestral recombination graphs"](https://doi.org/10.1101/2024.11.30.626138);
+in the future this might have more methods.
+
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,14 +15,14 @@ The reference documentation aims to be concise, precise and exhaustive;
     node_spans
     shared_node_spans
     match_node_ages
-    compare
+    haplotype_arf
 ```
 
 ```{eval-rst}
 .. autofunction:: tscompare.node_spans
 .. autofunction:: tscompare.shared_node_spans
 .. autofunction:: tscompare.match_node_ages
-.. autofunction:: tscompare.compare
+.. autofunction:: tscompare.haplotype_arf
 .. autoclass:: tscompare.ARFResult
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,8 +52,8 @@ Now, we can ask: how much of the inferred tree sequence is not "correct":
 in other words, how much of it is not represented in the true tree sequence?
 (Here, part of an ancestral node's span is "correct" if it is ancestral
 to the same set of samples.)
-We do this with {func}`.compare`:
+We do this with {func}`.haplotype_arf`:
 ```{code-cell}
-dis = tscompare.compare(orig_ts, inferred_ts)
+dis = tscompare.haplotype_arf(orig_ts, inferred_ts)
 print(dis)
 ```

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -198,6 +198,13 @@ class TestCladeMap:
 
 class TestNodeMatching:
 
+    def test_empty_ts(self):
+        ts = tskit.TableCollection(sequence_length=1.0).tree_sequence()
+        x = tscompare.node_spans(ts)
+        assert len(x) == 0
+        x = tscompare.shared_node_spans(ts, ts)
+        assert x.shape == (0, 0)
+
     @pytest.mark.parametrize(
         "ts",
         [true_simpl, true_unary],
@@ -253,6 +260,15 @@ class TestNodeMatching:
         assert np.all(np.isclose(node_spans_missing, true_spans_missing))
 
 
+class TestDeprecation:
+
+    @pytest.mark.filterwarnings("ignore:invalid value encountered in scalar divide")
+    def test_compare(self):
+        ts = tskit.TableCollection(sequence_length=1.0).tree_sequence()
+        with pytest.warns(DeprecationWarning):
+            _ = tscompare.compare(ts, ts)
+
+
 class TestMatchedSpans:
 
     def verify_compare(self, ts, other, transform=None):
@@ -269,6 +285,16 @@ class TestMatchedSpans:
         assert np.isclose(ts_span, dis.total_span[0])
         assert np.isclose(other_span, dis.total_span[1])
         assert np.isclose(rmse, dis.rmse), f"{rmse} != {dis.rmse}"
+
+    @pytest.mark.filterwarnings("ignore:invalid value encountered in scalar divide")
+    def test_empty_ts(self):
+        ts = tskit.TableCollection(sequence_length=1.0).tree_sequence()
+        x = tscompare.haplotype_arf(ts, ts)
+        assert np.isnan(x.arf)
+        assert np.isnan(x.tpr)
+        assert np.isnan(x.rmse)
+        assert x.matched_span == (0, 0)
+        assert x.total_span == (0, 0)
 
     def test_samples_dont_match(self):
         ts1 = tskit.Tree.generate_star(2).tree_sequence

--- a/tscompare/__init__.py
+++ b/tscompare/__init__.py
@@ -24,6 +24,7 @@ Tools for comparing tree sequences
 """
 from .methods import ARFResult  # noqa F401
 from .methods import CladeMap  # noqa F401
+from .methods import compare  # noqa F401
 from .methods import haplotype_arf  # noqa F401
 from .methods import match_node_ages  # noqa F401
 from .methods import node_spans  # noqa F401

--- a/tscompare/__init__.py
+++ b/tscompare/__init__.py
@@ -24,7 +24,7 @@ Tools for comparing tree sequences
 """
 from .methods import ARFResult  # noqa F401
 from .methods import CladeMap  # noqa F401
-from .methods import compare  # noqa F401
+from .methods import haplotype_arf  # noqa F401
 from .methods import match_node_ages  # noqa F401
 from .methods import node_spans  # noqa F401
 from .methods import shared_node_spans  # noqa F401

--- a/tscompare/methods.py
+++ b/tscompare/methods.py
@@ -261,7 +261,7 @@ def shared_node_spans(ts, other):
 def match_node_ages(ts, other):
     """
         For each node in `ts`, return the age of a matched node from `other`.  Node
-        matching is accomplished as described in :func:`.compare`.
+        matching is accomplished as described in :func:`.haplotype_arf`.
 
 
         Returns a tuple of three vectors of length `ts.num_nodes`, in this order:
@@ -290,7 +290,7 @@ def match_node_ages(ts, other):
 @dataclass
 class ARFResult:
     """
-    The result of a call to tscompare.compare(ts, other),
+    The result of a call to tscompare.haplotype_arf(ts, other),
     returning metrics associated with the ARG Robinson-Foulds
     measures of similarity and dissimilarity.
     This contains:
@@ -345,7 +345,7 @@ class ARFResult:
         return out
 
 
-def compare(ts, other, transform=None):
+def haplotype_arf(ts, other, transform=None):
     """
     For two tree sequences `ts` and `other`, this method returns an object of
     type :class:`.ARFResult`.  The values reported summarize the degree to
@@ -378,7 +378,7 @@ def compare(ts, other, transform=None):
 
     - (`matched_span`)
         The total "matching" and "inverse matching" spans between `ts` and `other`.
-        The "matching span" is the total span of all nodes in `ts` over with each
+        The "matching span" is the total span of all nodes in `ts` over which each
         node is ancestral to the same set of samples as its best match in `other`.
         The "inverse matching span" is the total span of all nodes in `other` over
         which each node is ancestral to the same set of sample as its best match in `ts`.


### PR DESCRIPTION
However, I'm keeping `compare` around, deprecated, to not break code (eg ours).

Closes #9.